### PR TITLE
feat(github): add github output

### DIFF
--- a/copr-gh-actions-submit
+++ b/copr-gh-actions-submit
@@ -77,6 +77,10 @@ build_url="https://copr.fedorainfracloud.org/coprs/build/$build_id/"
 
 echo "submitted build: $build_url"
 
+# set github workflow outputs
+echo "BUILD_ID=${build_id}" >> ${GITHUB_OUTPUT}
+echo "BUILD_URL=${build_url}" >> ${GITHUB_OUTPUT}
+
 set -o pipefail
 
 sed_search_state='s/.*"state":[[:space:]]*"\([a-z]*\)".*/\1/'


### PR DESCRIPTION
I would like the ability to cancel a copr build when a github workflow is cancelled. To do this I need to be able to access the `build_id` from outside of the step/script that called it.